### PR TITLE
chore: Compose integration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,5 @@
 import java.io.FileInputStream
-import java.util.*
+import java.util.Properties
 
 plugins {
     id("com.android.application")
@@ -26,7 +26,10 @@ android {
         }
     }
 
-    buildFeatures.viewBinding = true
+    buildFeatures {
+        viewBinding = true
+        compose = true
+    }
     buildTypes {
         getByName("debug") {
             isMinifyEnabled = false
@@ -46,6 +49,9 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.4.2"
     }
     defaultConfig {
         applicationId = AndroidConfig.applicationId
@@ -76,12 +82,21 @@ dependencies {
     implementation(Libraries.lifecycleExtensions)
     implementation(Libraries.lifecycleRuntimeKtx)
     implementation(Libraries.lifecycleJava8)
+    implementation(Libraries.lifecycleViewModelCompose)
 
     // androidx
     implementation(Libraries.activityKtx)
     implementation(Libraries.fragmentKtx)
     implementation(Libraries.swipeRefreshLayout)
     implementation(Libraries.palette)
+
+    // Jetpack Compose
+    implementation(platform(Libraries.composeBom))
+    implementation(Libraries.composeMaterial3)
+    implementation(Libraries.composeUiToolingPreview)
+    debugImplementation(Libraries.composeUiTooling)
+    implementation(Libraries.composeActivity)
+    implementation(Libraries.composeLiveData)
 
     // coroutines
     implementation(Libraries.coroutinesCore)
@@ -102,9 +117,13 @@ dependencies {
 
     // Coil - image loader
     implementation(Libraries.coil)
+    implementation(Libraries.coilCompose)
 
     // Material Dialog
     implementation(Libraries.materialDialog)
+
+    // View Binding Delegate
+    implementation(Libraries.bindingDelegate)
 
     // unit test
     testImplementation(Libraries.junit)
@@ -115,6 +134,7 @@ dependencies {
     androidTestImplementation(Libraries.espresso)
     androidTestImplementation(Libraries.androidxTest)
     androidTestImplementation(Libraries.androidxTestRules)
+    androidTestImplementation(platform(Libraries.composeBom))
 }
 
 fun getProperty(fileName: String, propName: String): Any? {

--- a/buildSrc/src/main/java/Depens.kt
+++ b/buildSrc/src/main/java/Depens.kt
@@ -1,30 +1,33 @@
 object AndroidConfig {
     const val applicationId = "com.jonathanlee.popcorn"
-    const val compileSdk = 31
+    const val compileSdk = 33
     const val minSdk = 23
-    const val targetSdk = 31
+    const val targetSdk = 33
     const val versionCode = 2
     const val versionName = "1.1"
 }
 
 object Versions {
-    const val gradle = "7.1.2"
+    const val gradle = "7.4.2"
 
     // Architectural Components
-    const val activityKtx = "1.4.0"
-    const val material = "1.4.0"
-    const val lifecycle = "2.2.0"
+    const val activityKtx = "1.7.0"
+    const val fragmentKtx = "1.5.6"
+    const val material = "1.8.0"
+    const val lifecycle = "2.6.1"
 
     // Coil - Image Loader
-    const val coil = "2.1.0"
+    const val coil = "2.3.0"
+
+    const val composeBom = "2023.03.00"
 
     // Google
     const val firebase = "2.7.1"
     const val googleServices = "4.3.10"
 
     // Kotlin
-    const val kotlin = "1.5.21"
-    const val coroutines = "1.5.1"
+    const val kotlin = "1.8.10"
+    const val coroutines = "1.6.4"
 
     // Material Dialog
     const val materialDialog = "3.3.0"
@@ -49,22 +52,35 @@ object Libraries {
     const val gradle = "com.android.tools.build:gradle:${Versions.gradle}"
 
     // Android
-    const val appCompat = "androidx.appcompat:appcompat:1.4.1"
+    const val appCompat = "androidx.appcompat:appcompat:1.6.1"
     const val constraintLayout = "androidx.constraintlayout:constraintlayout:2.1.3"
-    const val coreKtx = "androidx.core:core-ktx:1.7.0"
+    const val coreKtx = "androidx.core:core-ktx:1.10.0"
     const val palette = "androidx.palette:palette-ktx:1.0.0"
     const val swipeRefreshLayout = "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
 
     // Architectural Components
     const val activityKtx = "androidx.activity:activity-ktx:${Versions.activityKtx}"
-    const val fragmentKtx = "androidx.fragment:fragment-ktx:${Versions.activityKtx}"
+    const val fragmentKtx = "androidx.fragment:fragment-ktx:${Versions.fragmentKtx}"
     const val material = "com.google.android.material:material:${Versions.material}"
-    const val lifecycleExtensions = "androidx.lifecycle:lifecycle-extensions:${Versions.lifecycle}"
+    const val lifecycleExtensions = "androidx.lifecycle:lifecycle-extensions:2.2.0"
     const val lifecycleJava8 = "androidx.lifecycle:lifecycle-common-java8:${Versions.lifecycle}"
     const val lifecycleRuntimeKtx = "androidx.lifecycle:lifecycle-runtime-ktx:${Versions.lifecycle}"
+    const val lifecycleViewModelCompose = "androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1"
 
     // Coil - Image Loader
     const val coil = "io.coil-kt:coil:${Versions.coil}"
+    const val coilCompose = "io.coil-kt:coil-compose:${Versions.coil}"
+
+    // Jetpack Compose
+    const val composeActivity = "androidx.activity:activity-compose:1.6.1"
+    const val composeBom = "androidx.compose:compose-bom:${Versions.composeBom}"
+    const val composeLiveData = "androidx.compose.runtime:runtime-livedata"
+    const val composeMaterial3 = "androidx.compose.material3:material3"
+    const val composeMaterial2 = "androidx.compose.material:material"
+    const val composeUiTooling = "androidx.compose.ui:ui-tooling"
+    const val composeUiToolingPreview = "androidx.compose.ui:ui-tooling-preview"
+    const val composeUiTest = "androidx.compose.ui:ui-test-junit4"
+    const val composeUiTestManifest = "androidx.compose.ui:ui-test-manifest"
 
     // Coroutines
     const val coroutinesAndroid =
@@ -96,6 +112,9 @@ object Libraries {
     // Scrolling indicator
     const val scrollingIndicator =
         "ru.tinkoff.scrollingpagerindicator:scrollingpagerindicator:1.0.6"
+
+    // View Binding Delegate
+    const val bindingDelegate = "com.github.jonathanlee06:BindingDelegate:1.0.3"
 
     // Unit Test
     const val junit = "junit:junit:${Versions.junit}"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Sep 04 11:32:05 SGT 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven(url = "https://jitpack.io")
     }
 }
 rootProject.name = "Popcorn"


### PR DESCRIPTION
1. Bump compileSdk & targetSdk to 33
2. Bump AGP to 7.4.2
3. Bump activity-ktx to 1.7.0
4. Bump material to 1.8.0
5. Bump lifecycle to 2.6.1
6. Bump kotlin to 1.8.10
7. Bump gradle to 7.5.1
7. Add composeBom at 2023.03.00
8. Add bindingDelegate at 1.0.3